### PR TITLE
Catch2 cmake fix

### DIFF
--- a/cmake/setup_catch.cmake
+++ b/cmake/setup_catch.cmake
@@ -40,13 +40,13 @@ function(setup_catch target_name)
 
     get_target_property(Catch2_INCLUDE_DIRS Catch2::Catch2 INCLUDE_DIRECTORIES)
     # Add Catch2 as a dependency and link it to the target
-    add_dependencies(${target_name}_test Catch2::Catch2)
-    target_include_directories(${target_name}_test PUBLIC ${Catch2_INCLUDE_DIRS})
-    target_link_libraries(${target_name}_test PUBLIC Catch2::Catch2WithMain)
+    add_dependencies(${target_name} Catch2::Catch2)
+    target_include_directories(${target_name} PUBLIC ${Catch2_INCLUDE_DIRS})
+    target_link_libraries(${target_name} PUBLIC Catch2::Catch2WithMain)
 
     list(APPEND CMAKE_MODULE_PATH "${Catch2_SOURCE_DIR}/extras")
 
     include(CTest)
     include(Catch)
-    catch_discover_tests(${target_name}_test)
+    catch_discover_tests(${target_name})
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,4 +28,4 @@ target_compile_options(${PROJECT_NAME}_test
 target_compile_features(${PROJECT_NAME}_test PRIVATE cxx_std_23)
 
 include(setup_catch)
-setup_catch(${PROJECT_NAME})
+setup_catch(${PROJECT_NAME}_test)


### PR DESCRIPTION
calling setup_catch with FawnMemory_test in CMakeList.txt removing _test from setup_catch.cmake